### PR TITLE
Scaffold basic frontend and backend

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,1 +1,0 @@
-// Backend server entry point 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,1 +1,21 @@
-{} 
+{
+  "name": "voice-sales-backend",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import { v4 as uuid } from 'uuid';
+
+dotenv.config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
+
+interface Session {
+  id: string;
+  messages: { user: string; bot: string }[];
+}
+
+const sessions = new Map<string, Session>();
+
+app.post('/api/start-session', (_req, res) => {
+  const id = uuid();
+  sessions.set(id, { id, messages: [] });
+  res.json({ sessionId: id });
+});
+
+app.post('/api/submit-message', (req, res) => {
+  const { sessionId, message } = req.body as { sessionId: string; message: string };
+  if (!sessionId || !message || !sessions.has(sessionId)) {
+    return res.status(400).json({ error: 'Invalid session or message' });
+  }
+
+  const session = sessions.get(sessionId)!;
+  const reply = `Echo: ${message}`; // placeholder for OpenAI response
+  session.messages.push({ user: message, bot: reply });
+
+  res.json({ reply, score: 0 });
+});
+
+app.get('/api/leaderboard', (_req, res) => {
+  // placeholder leaderboard data
+  const leaderboard = Array.from(sessions.values()).map((s) => ({
+    sessionId: s.id,
+    messages: s.messages.length,
+  }));
+  res.json(leaderboard);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pitch Perfect</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,1 +1,25 @@
-{} 
+{
+  "name": "voice-sales-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.26",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.1.6",
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+export default function App() {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+  const [sessionId, setSessionId] = useState<string | null>(null);
+
+  const ensureSession = async () => {
+    if (sessionId) return sessionId;
+    const res = await fetch('/api/start-session', { method: 'POST' });
+    const data = await res.json();
+    setSessionId(data.sessionId);
+    return data.sessionId as string;
+  };
+
+  const sendMessage = async () => {
+    const id = await ensureSession();
+    const res = await fetch('/api/submit-message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: id, message: input }),
+    });
+    const data = await res.json();
+    setMessages((prev) => [...prev, `You: ${input}`, `Bot: ${data.reply}`]);
+    setInput('');
+  };
+
+  return (
+    <div className="p-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Pitch Perfect</h1>
+      <div className="space-y-2 min-h-[200px]">
+        {messages.map((m, i) => (
+          <p key={i}>{m}</p>
+        ))}
+      </div>
+      <div className="mt-4 flex gap-2">
+        <input
+          className="border p-2 flex-grow"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          className="bg-blue-500 text-white px-4 py-2"
+          onClick={sendMessage}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,1 +1,11 @@
-// Vite configuration stub 
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold TypeScript Express backend with basic session endpoints
- create React + Vite frontend using Tailwind CSS
- add Tailwind and TypeScript configs
- wire simple chat UI that calls backend

## Testing
- `npm run build` in `backend` *(fails: Cannot find module 'express')*
- `npm run build` in `frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8da64d78832cbadc0777b2104ae5